### PR TITLE
ログイン・ログアウトなど

### DIFF
--- a/app/assets/stylesheets/meeting_times.scss
+++ b/app/assets/stylesheets/meeting_times.scss
@@ -1,7 +1,0 @@
-
-/* 面談時間登録ページ */
-
-.box{
-  display: table-cell;  // 横揃え
-  text-align: center;
-}

--- a/app/assets/stylesheets/meetings.scss
+++ b/app/assets/stylesheets/meetings.scss
@@ -6,6 +6,7 @@
   font-size: 50px;
   font-family: 'M PLUS Rounded 1c';
   margin-bottom: 30px;
+  margin-top: 30px;
 }
 
 #meeting-title {

--- a/app/assets/stylesheets/meetings.scss
+++ b/app/assets/stylesheets/meetings.scss
@@ -29,6 +29,13 @@
   margin-top: 20px;
 }
 
+/* 面談時間登録ページ */
+
+.box{
+  display: table-cell;  // 横揃え
+  text-align: center;
+}
+
 /* datepicker */
 
 .ui-datepicker .ui-datepicker-header {  //header部分

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -1,3 +1,11 @@
 // Place all the styles related to the StaticPages controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+#teacher-login {
+  text-align: center;
+  margin-top: 20px;
+  font-size: 30px;
+  font-family: 'M PLUS Rounded 1c';
+}

--- a/app/assets/stylesheets/teachers.scss
+++ b/app/assets/stylesheets/teachers.scss
@@ -1,15 +1,19 @@
 
 /* 教員トップページ */
 
-#top {
+#teacher-top {
   text-align: center;
   #one,#two,#three,#four,#five {
     margin-top: 20px;
-    .top-submit {
-      width: 30%;
+    .top-button {
+      width: 40%;
+      font-size: 18px;
+      font-family: 'M PLUS Rounded 1c';
     }
     .last {
-      width: 60%;
+      width: 80%;
+      font-size: 18px;
+      font-family: 'M PLUS Rounded 1c';
     }
   }
 }
@@ -22,8 +26,9 @@
   border:1px solid #000;
   background-color:#F9F9F9;
   color:#000;
-  font-size:12px;
+  font-size:15px;
   margin: auto;
+  font-family: 'M PLUS Rounded 1c';
 }
 
 .box_title{
@@ -31,7 +36,8 @@
   padding:5px;
   width:500px;
   font-weight:bold;
-  font-size:14px;
+  font-size:18px;
+  font-family: 'M PLUS Rounded 1c';
   background-color:#000;
   color:#fff;
   text-align: center;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,14 @@
+
+/* 保護者トップページ */
+
+#user-top {
+  text-align: center;
+  #one,#two,#three,#four,#five,#six {
+    margin-top: 20px;
+    .top-button {
+      width: 50%;
+      font-size: 18px;
+      font-family: 'M PLUS Rounded 1c';
+    }
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,12 +1,14 @@
 class SessionsController < ApplicationController
 
+  # 保護者ログインページ(rootページでもある)
   def new
   end
 
+  # 教員ログインページ
   def new2
-
   end
 
+  # 保護者ログイン処理
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
@@ -19,9 +21,31 @@ class SessionsController < ApplicationController
     end
   end
 
+  # 教員ログイン処理
+  def create2
+    teacher = Teacher.find_by(email: params[:session][:email].downcase)
+    if teacher && teacher.authenticate(params[:session][:password])
+      log_in_teacher teacher
+      params[:session][:remember_me] == '2' ? remember_teacher(teacher) : forget_teacher(teacher)
+      redirect_to teacher
+    else
+      flash.now[:danger] = '認証に失敗しました。'
+      render :new2
+    end
+  end
+
+  # 保護者ログアウト処理
   def destroy
     log_out if logged_in?
     flash[:success] = 'ログアウトしました。'
     redirect_to root_url
   end
+
+  # 教員ログアウト処理
+  def destroy2
+    log_out_teacher if logged_in_teacher?
+    flash[:success] = 'ログアウトしました。'
+    redirect_to root_url
+  end
+
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,12 @@
 class SessionsController < ApplicationController
-  
+
   def new
   end
-  
+
+  def new2
+
+  end
+
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
@@ -14,7 +18,7 @@ class SessionsController < ApplicationController
       render :new
     end
   end
-  
+
   def destroy
     log_out if logged_in?
     flash[:success] = 'ログアウトしました。'

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
   def top
   end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,28 +1,55 @@
 class UsersController < ApplicationController
 
+  # 保護者トップページ
   def show
     @user = User.find(params[:id])
     @child = Child.where(user_id: @user.id).first
+    if @child.nil?
+      redirect_to signup_child_url
+    end
   end
 
+  # 保護者新規作成ページ
   def new
     @user = User.new
   end
 
+  # 生徒新規登録ページ
+  def new2
+    @user = User.find(params[:id])
+    @child = @user.children.build
+  end
+
+  # 保護者新規登録
   def create
     @user = User.new(user_params)
     if @user.save
       log_in @user
-      flash[:success] = '新規作成に成功しました。'
+      flash[:success] = 'アカウントを作成しました。次に生徒登録をしてください。'
       redirect_to @user
     else
       render :new
     end
   end
 
+  # 生徒新規登録
+  def create2
+    @user = User.find(params[:id])
+    @child = @user.children.build(name_1: params[:name_1], name_2: params[:name_2], teacher_id: 1)
+    if @child.save
+      flash[:success] = '生徒の登録をしました。もう一人登録する場合はトップページの新規登録からお願いします。'
+      @child.update_attributes(full_name: "#{@child.name_1}#{@child.name_2}")
+      redirect_to @user
+    else
+      flash.now[:danger] = "入力内容が間違っています。"
+      render :new2
+    end
+  end
+
   private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation)
+      params.require(:user).permit(:name, :name2, :email, :phone, :password, :password_confirmation)
     end
+
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -19,8 +19,8 @@ module SessionsHelper
 
   # 教員remember
   def remember_teacher(teacher)
-    teacher.remember
-    cookies.permanent.signed[:user_id] = teacher.id
+    teacher.remember_teacher
+    cookies.permanent.signed[:teacher_id] = teacher.id
     cookies.permanent[:remember_token] = teacher.remember_token
   end
 
@@ -33,9 +33,9 @@ module SessionsHelper
 
   # 教員forget
   def forget_teacher(teacher)
-    teacher.forget
+    teacher.forget_teacher
     cookies.delete(:teacher_id)
-    cookies.delete(:teacher_token)
+    cookies.delete(:remember_token)
   end
 
   # 保護者ログアウト
@@ -47,9 +47,9 @@ module SessionsHelper
 
   # 教員ログアウト
   def log_out_teacher
-    forget(current_teacher)
+    forget_teacher(current_teacher)
     session.delete(:teacher_id)
-    @current_user = nil
+    @current_teacher = nil
   end
 
   # 保護者現在ユーザー
@@ -71,8 +71,8 @@ module SessionsHelper
       @current_teacher ||= Teacher.find_by(id: teacher_id)
     elsif (teacher_id = cookies.signed[:teacher_id])
       teacher = Teacher.find_by(id: teacher_id)
-      if teacher && teacher.authenticated?(cookies[:remember_token])
-        log_in teacher
+      if teacher && teacher.authenticated_teacher?(cookies[:remember_token])
+        log_in_teacher teacher
         @current_teacher = teacher
       end
     end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,17 +21,17 @@ class Teacher < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  def remember
+  def remember_teacher
     self.remember_token = Teacher.new_token
     update_attribute(:remember_digest, Teacher.digest(remember_token))
   end
 
-  def authenticated?(remember_token)
+  def authenticated_teacher?(remember_token)
     return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 
-  def forget
+  def forget_teacher
     update_attribute(:remember_digest, nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,33 +2,36 @@ class User < ApplicationRecord
   attr_accessor :remember_token
   before_save { self.email = email.downcase }
   has_many :documents
+  has_many :children, dependent: :destroy
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :name,  presence: true, length: { maximum: 50 }
+  validates :name,  presence: true, length: { maximum: 30 }
+  validates :name2, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 100 },
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: true
+  validates :phone, presence: true, length: { maximum: 20 }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
-  
+
   def User.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
   end
-  
+
   def User.new_token
     SecureRandom.urlsafe_base64
   end
-  
+
   def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
-  
+
   def authenticated?(remember_token)
     return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
-  
+
   def forget
     update_attribute(:remember_digest, nil)
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,24 +1,39 @@
 <header class="navbar navbar-fixed-top navbar-inverse">
   <div class="container">
-    <%= link_to "Sample App", root_path, id: "logo" %>
+    <% if logged_in? %>
+      <%= link_to "学校の面談と提出管理アプリ", user_path(@user), id: "logo" %>
+    <% elsif logged_in_teacher? %>
+      <%= link_to "学校の面談と提出管理アプリ", teacher_path(@teacher), id: "logo" %>
+    <% else %>
+      <%= link_to "学校の面談と提出管理アプリ", root_path, id: "logo" %>
+    <% end %>
+
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Top", root_path %></li>
-        <% if logged_in? %>
+        <li><%= link_to "Top", "#" %></li>
+        <% if logged_in? || logged_in_teacher? %>
           <li><%= link_to "Users", '#' %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               Account <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
-              <li><%= link_to "Show", current_user %></li>
+              <li><%= link_to "Show", "#" %></li>
               <li><%= link_to "Settings", '#' %></li>
               <li class="divider"></li>
-              <li><%= link_to "Log out", logout_path, method: :delete %></li>
+              <li>
+                <% if logged_in? %>
+                  <%= link_to "ログアウト", logout_path, method: :delete %>
+                <% else %>
+                  <%= link_to "ログアウト", teacher_logout_path, method: :delete %>
+                <% end %>
+              </li>
             </ul>
           </li>
         <% else %>
-          <li><%= link_to "Log in", login_path %></li>
+          <li>
+            <%= link_to "ログイン", root_path %>
+          </li>
         <% end %>
       </ul>
     </nav>

--- a/app/views/meetings/new_user.html.erb
+++ b/app/views/meetings/new_user.html.erb
@@ -1,7 +1,7 @@
 <div id="meeting-top-title"><%= @child.full_name %>さんの面談管理ページ</div>
 
 <% unless @meeting_children.present? %>
-  <h1>現在面談予定はございません。</h1>
+  <h1 id="meeting-top-title">現在面談予定はございません。</h1>
 <% else %>
 
   <!-- 子供が二人以上いた場合 -->

--- a/app/views/sessions/new2.html.erb
+++ b/app/views/sessions/new2.html.erb
@@ -16,12 +16,8 @@
       <% end %>
 
       <div id="submit-center">
-        <%= link_to "新規登録", signup_path, class: "btn btn-lg btn-success submit-width" %>
         <%= f.submit "ログイン", class: "btn btn-lg btn-primary submit-width" %>
       </div>
     <% end %>
-    <div id="teacher-login">
-      <%= link_to "教員はこちら", login_teacher_path %>
-    </div>
   </div>
 </div>

--- a/app/views/sessions/new2.html.erb
+++ b/app/views/sessions/new2.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(scope: :session, url: login_path, local: true) do |f| %>
+    <%= form_with(scope: :session, url: teacher_login_path, local: true) do |f| %>
 
       <%= f.label :email, "メールアドレス", class: "label-login" %>
       <%= f.email_field :email, class: 'form-control' %>
@@ -19,5 +19,8 @@
         <%= f.submit "ログイン", class: "btn btn-lg btn-primary submit-width" %>
       </div>
     <% end %>
+    <div id="teacher-login">
+      <%= link_to "保護者はこちら", root_path %>
+    </div>
   </div>
 </div>

--- a/app/views/teachers/show.html.erb
+++ b/app/views/teachers/show.html.erb
@@ -1,4 +1,4 @@
-<h1>教員トップページ</h1>
+<h1 id="meeting-top-title">教員トップページ</h1>
 
 <div class="box_title">保護者からのお問い合わせ</div>
 <div class="box_srcollbar">
@@ -17,49 +17,49 @@
     09/17　○■■○○■■■を追加しました。<br>
 </div>
 
-<div id="top">
+<div id="teacher-top">
   <div id="one">
-    <%= link_to  teacher_meetings_new_path(@teacher), class: "btn btn-success top-submit" do %>
+    <%= link_to  teacher_meetings_new_path(@teacher), class: "btn btn-success top-button" do %>
        <%= image_tag('/icon/cl.png',size:"20x20") %>
        面談日登録
     <% end %>
-    <%= link_to  teacher_meetings_edit_path(@teacher), class: "btn btn-info top-submit" do %>
+    <%= link_to  teacher_meetings_edit_path(@teacher), class: "btn btn-info top-button" do %>
        <%= image_tag('/icon/time.png',size:"20x20") %>
        面談日時編集
     <% end %>
   </div>
   <div id="two">
-    <%= link_to  teacher_meeting_index2_path(@teacher), class: "btn btn-default top-submit" do %>
+    <%= link_to  teacher_meeting_index2_path(@teacher), class: "btn btn-default top-button" do %>
       <%= image_tag('/icon/sk.png',size:"20x20") %>
       面談返信状況確認
     <% end %>
-    <%= link_to  documents_path, class: "btn btn-danger top-submit" do %>
+    <%= link_to  documents_path, class: "btn btn-danger top-button" do %>
        <%= image_tag('/icon/dk.png',size:"20x20") %>
        提出状況確認
     <% end %>
   </div>
   <div id="three">
-    <%= link_to new2_document_path, class: "btn btn-warning top-submit" do %>
+    <%= link_to new2_document_path, class: "btn btn-warning top-button" do %>
        <%= image_tag('/icon/input0.png',size:"20x20") %>
        入力式提出
     <% end %>
-    <%= link_to  new_document_path, class: "btn btn-primary top-submit" do %>
+    <%= link_to  new_document_path, class: "btn btn-primary top-button" do %>
       <%= image_tag('/explain/form.png',size:"20x20") %>
       選択式提出
     <% end %>
   </div>
   <div id="four">
-    <%= link_to  new3_document_path, class: "btn btn-default top-submit" do %>
+    <%= link_to  new3_document_path, class: "btn btn-default top-button" do %>
       <%= image_tag('/explain/pdf.png',size:"20x20") %>
       表示書類
     <% end %>
-    <%= link_to  "#", class: "btn btn-success top-submit" do %>
+    <%= link_to  "#", class: "btn btn-success top-button" do %>
       <%= image_tag('/icon/mail.png',size:"20x20") %>
       個別連絡
     <% end %>
   </div>
   <div id="five">
-    <%= link_to  "#", class: "btn btn-info top-submit last" do %>
+    <%= link_to  "#", class: "btn btn-info top-button last" do %>
     <%= image_tag('/icon/pe.png',size:"20x20") %>
     保護者一覧
     <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,24 +1,29 @@
-<% provide(:title, 'Sign up') %>
-<h1>ユーザー登録</h1>
+<div id="meeting-top-title">保護者新規登録</div>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_with(model: @user, local: true) do |f| %>
       <%= render 'shared/error_messages' %>
 
-      <%= f.label :name, class: "label-signup" %>
+      <%= f.label :name, "姓", class: "label-signup" %>
       <%= f.text_field :name, class: "form-control" %>
 
-      <%= f.label :email, class: "label-signup" %>
+      <%= f.label :name2, "名", class: "label-signup" %>
+      <%= f.text_field :name2, class: "form-control" %>
+
+      <%= f.label :email, "メールアドレス", class: "label-signup" %>
       <%= f.email_field :email, class: "form-control" %>
 
-      <%= f.label :password, class: "label-signup" %>
+      <%= f.label :phone, "電話番号", class: "label-signup" %>
+      <%= f.text_field :phone, class: "form-control" %>
+
+      <%= f.label :password, "パスワード", class: "label-signup" %>
       <%= f.password_field :password, class: "form-control" %>
 
-      <%= f.label :password_confirmation, "Confirmation", class: "label-signup" %>
+      <%= f.label :password_confirmation, "パスワード確認", class: "label-signup" %>
       <%= f.password_field :password_confirmation, class: "form-control" %>
 
-      <%= f.submit "Sign Up", class: "btn btn-primary btn-block btn-signup" %>
+      <%= f.submit "登録", class: "btn btn-primary btn-block btn-signup" %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/new2.html.erb
+++ b/app/views/users/new2.html.erb
@@ -1,0 +1,17 @@
+<div id="meeting-top-title">生徒新規登録</div>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: child_create2_path(@user), local: true) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= f.label :name_1, "姓", class: "label-signup" %>
+      <%= f.text_field :name_1, class: "form-control" %>
+
+      <%= f.label :name_2, "名", class: "label-signup" %>
+      <%= f.text_field :name_2, class: "form-control" %>
+
+      <%= f.submit "登録", class: "btn btn-primary btn-block btn-signup" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,24 @@
-<h1><%= @user.name + @user.name2 %></h1>
+<h1 id="meeting-top-title"><%= @user.name + @user.name2 %>さんの管理ページ</h1>
 
 
-<div id="top">
-
-  <%= link_to "面談ページへ", user_meetings_new_user_path(user_id: @user.id, child_id: @child.id), class: "btn btn-success top-submit" %>
-
-  <%= link_to "提出ページへ", "#", class: "btn btn-info top-submit" %>
+<div id="user-top">
+  <div id="one">
+    <%= link_to "面談ページへ", user_meetings_new_user_path(user_id: @user.id, child_id: @child.id), class: "btn btn-success top-button" %>
+  </div>
+  <div id="two">
+    <%= link_to "提出ページへ", "#", class: "btn btn-success top-button" %>
+  </div>
+  <div id="three">
+    <%= link_to "保護者情報編集", "#", class: "btn btn-success top-button" %>
+  </div>
+  <div id="four">
+    <%= link_to "生徒さん登録/編集", "#", class: "btn btn-success top-button" %>
+  </div>
+  <div id="five">
+    <%= link_to "先生へ連絡する", "#", class: "btn btn-success top-button" %>
+  </div>
+  <div id="six">
+    <%= link_to "先生からのお便り", "#", class: "btn btn-success top-button" %>
+  </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
 
-  root to: 'sessions#new'
-  get  '/login/teacher', to: 'sessions#new2'
-  get '/signup', to: 'users#new'
+  root to: 'sessions#new'                                                                                      # 保護者ログインページ
+  get  '/login/teacher', to: 'sessions#new2'                                                                   # 教員ログインページ
+  get '/signup', to: 'users#new'                                                                               # 保護者新規作成ページ
 
-  # get    '/login', to: 'sessions#new'
-  post   '/login', to: 'sessions#create'
-  delete '/logout', to: 'sessions#destroy'
+  post   '/login', to: 'sessions#create'                                                                       # 保護者ログイン処理
+  post   '/login/teacher', to: 'sessions#create2', as: :teacher_login                                          # 教員ログイン処理
+  delete '/logout', to: 'sessions#destroy'                                                                     # 保護者ログアウト処理
+  delete '/logout/teacher', to: 'sessions#destroy2', as: :teacher_logout                                       # 教員ログアウト処理
 
   resources :teachers do
     get 'meetings/new', to: 'meetings#new'                                                                     # 面談日時登録ページ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,14 @@
 Rails.application.routes.draw do
 
-  root 'static_pages#top'
+  root to: 'sessions#new'
+  get  '/login/teacher', to: 'sessions#new2'
   get '/signup', to: 'users#new'
 
-  get    '/login', to: 'sessions#new'
+  # get    '/login', to: 'sessions#new'
   post   '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
   resources :teachers do
-
     get 'meetings/new', to: 'meetings#new'                                                                     # 面談日時登録ページ
     post 'meetings/create', to: 'meetings#create', as: :meeting_create                                         # 面談日作成
     post 'meetings/create2', to: 'meetings#create2', as: :meeting_create2                                      # 面談時間作成
@@ -45,10 +45,10 @@ Rails.application.routes.draw do
   delete "document/file_delete/:document_id",to:"documents#file_delete",as: :file_delete                       #教員ファイル削除
   get "document/public_change/:document_id",to:"documents#public_change",as: :public_change                    #保護者へ提出
   get 'select_document/first',to:'documents#select_modal',as: :select_first_modal                              #選択式最初のページモーダル
-  get 'select_document/second',to:'document_items#select_modal',as: :select_second_modal                       #選択式2番目のページモーダル 
-  get 'select_document/third',to:'document_selects#select_modal',as: :select_third_modal                       #選択式3番目のページモーダル 
+  get 'select_document/second',to:'document_items#select_modal',as: :select_second_modal                       #選択式2番目のページモーダル
+  get 'select_document/third',to:'document_selects#select_modal',as: :select_third_modal                       #選択式3番目のページモーダル
   get 'input_document/first',to:'documents#input_modal',as: :input_first_modal                                 #入力式最初のページモーダル
-  get 'input_document/second',to:'document_items#input_modal',as: :input_second_modal                          #入力式2番目のページモーダル 
+  get 'input_document/second',to:'document_items#input_modal',as: :input_second_modal                          #入力式2番目のページモーダル
 
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root to: 'sessions#new'                                                                                      # 保護者ログインページ
   get  '/login/teacher', to: 'sessions#new2'                                                                   # 教員ログインページ
   get '/signup', to: 'users#new'                                                                               # 保護者新規作成ページ
+  get '/signup/:id/child', to: 'users#new2', as: :signup_child                                                     # 生徒新規作成ページ
+  post '/users/:id/child', to: 'users#create2', as: :child_create2                                                 # 生徒新規登録
 
   post   '/login', to: 'sessions#create'                                                                       # 保護者ログイン処理
   post   '/login/teacher', to: 'sessions#create2', as: :teacher_login                                          # 教員ログイン処理

--- a/db/migrate/20191118063413_create_meetings.rb
+++ b/db/migrate/20191118063413_create_meetings.rb
@@ -5,7 +5,6 @@ class CreateMeetings < ActiveRecord::Migration[5.1]
       t.string :nottime
       t.integer :status, default: 3
       t.boolean :desired, default: false
-      t.string :randam
       t.references :teacher, foreign_key: true
       t.references :child, foreign_key: true
 

--- a/db/migrate/20191128001511_add_phone_to_users.rb
+++ b/db/migrate/20191128001511_add_phone_to_users.rb
@@ -1,0 +1,5 @@
+class AddPhoneToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :phone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 20191125081727) do
 
   create_table "document_items", force: :cascade do |t|
     t.text "content"
-    t.string "randam"
+    t.string "radam"
     t.integer "document_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -59,10 +59,11 @@ ActiveRecord::Schema.define(version: 20191125081727) do
     t.date "deadline"
     t.string "randam"
     t.boolean "public", default: false
-    t.integer "user_id"
+    t.integer "teacher_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "item_check", default: false
+    t.index ["teacher_id"], name: "index_documents_on_teacher_id"
   end
 
   create_table "meeting_times", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191125081727) do
+ActiveRecord::Schema.define(version: 20191128001511) do
 
   create_table "answers", force: :cascade do |t|
     t.text "reply"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 20191125081727) do
     t.string "password_digest"
     t.string "remember_digest"
     t.string "name2"
+    t.string "phone"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,10 +3,11 @@
 require 'faker/japanese'
 
 
-User.create!( name: "Sample User",
-              email: "sample@email.com",
-              password: "password",
-              password_confirmation: "password")
+Teacher.create!( name: "教員",
+                 email: "teacher@example.com",
+                 password: "password",
+                 password_confirmation: "password")
+
 20.times do |n|
   name = Faker::Japanese::Name.last_name
   name2 = Faker::Japanese::Name.first_name


### PR DESCRIPTION
1. 保護者、教員それぞれのログインページとそれぞれのsession処理
2. headerロゴから各々のトップページに遷移、headerのドロップダウンにログアウトボタン追加
3. meetingテーブルからrandamカラム削除。migrationファイルの中身から削除。使わなかったため
4. usersテーブルにphoneカラム追加。なかったため
5. 保護者、教員トップページの調整など