### PR TITLE
保護者一覧ページ、保護者と生徒の編集・更新の実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -12,3 +12,13 @@
     }
   }
 }
+
+/* 生徒登録/編集ページ */
+
+#child-signup {
+  text-align: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  font-size: 30px;
+  font-family: 'M PLUS Rounded 1c';
+}

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,7 +1,16 @@
 class TeachersController < ApplicationController
+
+  # 教員トップページ
   def show
     @teacher = Teacher.find(params[:id])
     #教員ページにてitem_check/select_check(途中でブラウザ閉じurlによるページ移動)trueでdocument_item/document_selectゼロならdocument削除
     document_delete2
   end
+
+  # 保護者一覧ページ
+  def index2
+    @teacher = Teacher.find(params[:teacher_id])
+    @users = User.all
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,10 +65,55 @@ class UsersController < ApplicationController
     redirect_to teacher_teacher_index2_url(params[:teacher_id])
   end
 
-  private
+  # 保護者編集ページ
+  def edit
+    @user = User.find(params[:id])
+  end
 
+  # 保護者更新
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+      flash[:success] = "#{@user.name + @user.name2}さんの登録情報を更新しました。"
+      redirect_to user_url(@user)
+    else
+      flash[:danger] = "失敗"
+      redirect_to user_url(@user)
+    end
+  end
+
+  # 生徒情報登録/編集ページ
+  def index2
+    @user = User.find(params[:user_id])
+    @children = @user.children.all
+  end
+
+  # 生徒情報編集ページ
+  def edit2
+    @user = User.find(params[:user_id])
+    @child = @user.children.find(params[:child_id])
+  end
+
+  # 生徒情報更新
+  def update2
+    @user = User.find(params[:user_id])
+    @child = @user.children.find(params[:child_id])
+    if @child.update_attributes(child_params)
+      @child.update_attributes(full_name: @child.name_1 + @child.name_2)
+      flash[:success] = "生徒さん情報を更新しました。"
+      redirect_to user_users_index2_url(@user)
+    end
+  end
+
+  private
+    # 保護者情報登録/更新
     def user_params
       params.require(:user).permit(:name, :name2, :email, :phone, :password, :password_confirmation)
+    end
+
+    # 生徒情報登録/更新
+    def child_params
+      params.require(:child).permit(:name_1, :name_2)
     end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,15 +35,34 @@ class UsersController < ApplicationController
   # 生徒新規登録
   def create2
     @user = User.find(params[:id])
-    @child = @user.children.build(name_1: params[:name_1], name_2: params[:name_2], teacher_id: 1)
+    @child = @user.children.build(name_1: params[:name_1], name_2: params[:name_2], teacher_id: 1) # 先生が一人の場合のみ限定
+    @teacher = Teacher.find(@child.teacher_id)
+    @meetings = @teacher.meetings.all
     if @child.save
-      flash[:success] = '生徒の登録をしました。もう一人登録する場合はトップページの新規登録からお願いします。'
+      flash[:success] = '生徒の登録をしました。もう一人登録する場合はトップページの「生徒さん登録/編集」からお願いします。'
       @child.update_attributes(full_name: "#{@child.name_1}#{@child.name_2}")
+      # 面談日レコードが0でない場合、レコードを作る
+      dates.each do |day|
+        unless @teacher.meetings.any? {|meeting| meeting == @teacher.meetings.find_by(date: day, child_id: @child.id)}
+          @teacher.children.where(teacher_id: @teacher.id, user_id: @user.id).each do |child|   # 保護者紐付けの生徒が二人いた場合
+            record = @teacher.meetings.build(date: day, child_id: @child.id)
+            record.save
+          end
+        end
+      end
       redirect_to @user
     else
       flash.now[:danger] = "入力内容が間違っています。"
       render :new2
     end
+  end
+
+  # 保護者削除
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    flash[:danger] = "#{@user.name + @user.name2}さんの登録情報を削除しました。"
+    redirect_to teacher_teacher_index2_url(params[:teacher_id])
   end
 
   private

--- a/app/helpers/meetings_helper.rb
+++ b/app/helpers/meetings_helper.rb
@@ -57,7 +57,7 @@ module MeetingsHelper
   def desired_status(teacher, id)
     meetings = teacher.meetings.where(child_id: id)
     desired = meetings.map{|m| m.desired}
-    if meetings.first.date.present?
+    unless desired.empty?
       case true
         when *desired
           return "返信済み"

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,4 +1,5 @@
 class Child < ApplicationRecord
   belongs_to :teacher
   belongs_to :user
+  has_many :meetings, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
                     uniqueness: true
   validates :phone, presence: true, length: { maximum: 20 }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   def User.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost

--- a/app/views/meetings/index2.html.erb
+++ b/app/views/meetings/index2.html.erb
@@ -18,7 +18,7 @@
       <% @children.each do |child| %>
         <tr>
           <td><%= child.full_name %></td>
-          <% if desired_status(@teacher, child.id) =="返信済み" %>
+          <% if desired_status(@teacher, child.id) == "返信済み" %>
             <td style="color: red;"><%= desired_status(@teacher, child.id) %></td>
           <% else %>
             <td style="color: blue;"><%= desired_status(@teacher, child.id) %></td>

--- a/app/views/teachers/index2.html.erb
+++ b/app/views/teachers/index2.html.erb
@@ -1,0 +1,31 @@
+<div id="meeting-top-title">保護者一覧</div>
+
+<table class="table meeting-table">
+  <thead>
+    <tr>
+      <td>名前</td>
+      <td>メールアドレス</td>
+      <td>電話番号</td>
+      <td>ユーザー削除</td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td>
+          <div data-toggle="collapse" href="#<%= user.id %>" style="cursor: pointer;"><%= user.name + user.name2 %></div>
+            <div id="<%= user.id %>" class="panel-collapse collapse">
+              <% user.children.each do |child| %>
+                <div class="panel-body" style="color: red;">生徒名：<%= child.full_name %></div>
+              <% end %>
+            </div>
+          </div>
+        <td><%= user.email %></td>
+        <td><%= user.phone %></td>
+        <td><%= link_to "削除", user_path(id: user.id, teacher_id: @teacher.id), data: {confirm: "本当に削除しますか？"}, method: :delete, style: "color: red;" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+
+</table>

--- a/app/views/teachers/show.html.erb
+++ b/app/views/teachers/show.html.erb
@@ -29,11 +29,11 @@
     <% end %>
   </div>
   <div id="two">
-    <%= link_to  teacher_meeting_index2_path(@teacher), class: "btn btn-default top-button" do %>
+    <%= link_to teacher_meeting_index2_path(@teacher), class: "btn btn-default top-button" do %>
       <%= image_tag('/icon/sk.png',size:"20x20") %>
       面談返信状況確認
     <% end %>
-    <%= link_to  documents_path(params:{teacher_id: @teacher}), class: "btn btn-danger top-button" do %>
+    <%= link_to documents_path(params:{teacher_id: @teacher}), class: "btn btn-danger top-button" do %>
        <%= image_tag('/icon/dk.png',size:"20x20") %>
        提出状況確認
     <% end %>
@@ -43,23 +43,23 @@
        <%= image_tag('/icon/input0.png',size:"20x20") %>
        入力式提出
     <% end %>
-    <%= link_to  new_document_path(params:{teacher_id: @teacher}), class: "btn btn-primary top-button" do %>
+    <%= link_to new_document_path(params:{teacher_id: @teacher}), class: "btn btn-primary top-button" do %>
       <%= image_tag('/explain/form.png',size:"20x20") %>
       選択式提出
     <% end %>
   </div>
   <div id="four">
-    <%= link_to  new3_document_path(params:{teacher_id: @teacher}), class: "btn btn-default top-button" do %>
+    <%= link_to new3_document_path(params:{teacher_id: @teacher}), class: "btn btn-default top-button" do %>
       <%= image_tag('/explain/pdf.png',size:"20x20") %>
       表示書類
     <% end %>
-    <%= link_to  "#", class: "btn btn-success top-button" do %>
+    <%= link_to "#", class: "btn btn-success top-button" do %>
       <%= image_tag('/icon/mail.png',size:"20x20") %>
       個別連絡
     <% end %>
   </div>
   <div id="five">
-    <%= link_to  "#", class: "btn btn-info top-button last" do %>
+    <%= link_to teacher_teacher_index2_path(@teacher), class: "btn btn-info top-button last" do %>
     <%= image_tag('/icon/pe.png',size:"20x20") %>
     保護者一覧
     <% end %>

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_with(model: @user, local: true) do |f| %>
+  <%= render 'shared/error_messages' %>
+
+  <%= f.label :name, "姓", class: "label-signup" %>
+  <%= f.text_field :name, class: "form-control" %>
+
+  <%= f.label :name2, "名", class: "label-signup" %>
+  <%= f.text_field :name2, class: "form-control" %>
+
+  <%= f.label :email, "メールアドレス", class: "label-signup" %>
+  <%= f.email_field :email, class: "form-control" %>
+
+  <%= f.label :phone, "電話番号", class: "label-signup" %>
+  <%= f.text_field :phone, class: "form-control" %>
+
+  <%= f.label :password, "パスワード", class: "label-signup" %>
+  <%= f.password_field :password, class: "form-control" %>
+
+  <%= f.label :password_confirmation, "パスワード確認", class: "label-signup" %>
+  <%= f.password_field :password_confirmation, class: "form-control" %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary btn-block btn-signup" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,9 @@
+<% provide(:button_text, '更新') %>
+
+<div id="meeting-top-title"><%= @user.name + @user.name2 %>さんの情報編集</div>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render "user_form" %>
+  </div>
+</div>

--- a/app/views/users/edit2.html.erb
+++ b/app/views/users/edit2.html.erb
@@ -1,0 +1,17 @@
+<div id="meeting-top-title"><%= @child.full_name %>さんの編集</div>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @child, url: user_users_update2_path(user_id: params[:user_id], child_id: params[:child_id]), local: true) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= f.label :name_1, "姓", class: "label-signup" %>
+      <%= f.text_field :name_1, class: "form-control" %>
+
+      <%= f.label :name_2, "名", class: "label-signup" %>
+      <%= f.text_field :name_2, class: "form-control" %>
+
+      <%= f.submit "更新", class: "btn btn-primary btn-block btn-signup" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/index2.html.erb
+++ b/app/views/users/index2.html.erb
@@ -1,0 +1,15 @@
+<div id="meeting-top-title">生徒さんの編集と登録</div>
+
+<div id="child-signup">
+  <%= link_to "生徒さんの登録はこちら", signup_child_path(@user) %>
+</div>
+
+<table class="table meeting-table">
+  <tbody>
+    <% @children.each do |child| %>
+    <tr style="font-size: 25px;">
+      <td><%= link_to "#{child.full_name}さんの編集", user_users_edit2_path(user_id: @user.id, child_id: child.id) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,29 +1,9 @@
+<% provide(:button_text, '新規作成') %>
+
 <div id="meeting-top-title">保護者新規登録</div>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user, local: true) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name, "姓", class: "label-signup" %>
-      <%= f.text_field :name, class: "form-control" %>
-
-      <%= f.label :name2, "名", class: "label-signup" %>
-      <%= f.text_field :name2, class: "form-control" %>
-
-      <%= f.label :email, "メールアドレス", class: "label-signup" %>
-      <%= f.email_field :email, class: "form-control" %>
-
-      <%= f.label :phone, "電話番号", class: "label-signup" %>
-      <%= f.text_field :phone, class: "form-control" %>
-
-      <%= f.label :password, "パスワード", class: "label-signup" %>
-      <%= f.password_field :password, class: "form-control" %>
-
-      <%= f.label :password_confirmation, "パスワード確認", class: "label-signup" %>
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-
-      <%= f.submit "登録", class: "btn btn-primary btn-block btn-signup" %>
-    <% end %>
+    <%= render "user_form" %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,10 +9,10 @@
     <%= link_to "提出ページへ", "#", class: "btn btn-success top-button" %>
   </div>
   <div id="three">
-    <%= link_to "保護者情報編集", "#", class: "btn btn-success top-button" %>
+    <%= link_to "保護者情報編集", edit_user_path(@user), class: "btn btn-success top-button" %>
   </div>
   <div id="four">
-    <%= link_to "生徒さん登録/編集", "#", class: "btn btn-success top-button" %>
+    <%= link_to "生徒さん登録/編集", user_users_index2_path(@user), class: "btn btn-success top-button" %>
   </div>
   <div id="five">
     <%= link_to "先生へ連絡する", "#", class: "btn btn-success top-button" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   delete '/logout/teacher', to: 'sessions#destroy2', as: :teacher_logout                                       # 教員ログアウト処理
 
   resources :teachers do
-    get 'index2', to: 'teachers#index2', as: :teacher_index2                                              # 保護者一覧ページ
+    get 'index2', to: 'teachers#index2', as: :teacher_index2                                                   # 保護者一覧ページ
     get 'meetings/new', to: 'meetings#new'                                                                     # 面談日時登録ページ
     post 'meetings/create', to: 'meetings#create', as: :meeting_create                                         # 面談日作成
     post 'meetings/create2', to: 'meetings#create2', as: :meeting_create2                                      # 面談時間作成
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
   end
 
   resources :users do
+    get  'children/index2', to: 'users#index2', as: :users_index2                                              # 生徒情報登録/編集ページ
+    get  ':child_id/edit2', to: 'users#edit2', as: :users_edit2                                                # 生徒情報編集ページ
+    patch ':child_id/edit2', to: 'users#update2', as: :users_update2                                           # 生徒情報更新
     get  ':child_id/meetings/new_user', to: 'meetings#new_user', as: :meetings_new_user                        # 保護者面談日時登録ページ
     get  ':child_id/meetings/desired', to: 'meetings#desired', as: :meetings_desired                           # 希望日登録モーダル
     patch ':child_id/meetings/desired', to: 'meetings#desired_update', as: :desired_update                     # 面談希望日等決定

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
   root to: 'sessions#new'                                                                                      # 保護者ログインページ
   get  '/login/teacher', to: 'sessions#new2'                                                                   # 教員ログインページ
   get '/signup', to: 'users#new'                                                                               # 保護者新規作成ページ
-  get '/signup/:id/child', to: 'users#new2', as: :signup_child                                                     # 生徒新規作成ページ
-  post '/users/:id/child', to: 'users#create2', as: :child_create2                                                 # 生徒新規登録
+  get '/signup/:id/child', to: 'users#new2', as: :signup_child                                                 # 生徒新規作成ページ
+  post '/users/:id/child', to: 'users#create2', as: :child_create2                                             # 生徒新規登録
 
   post   '/login', to: 'sessions#create'                                                                       # 保護者ログイン処理
   post   '/login/teacher', to: 'sessions#create2', as: :teacher_login                                          # 教員ログイン処理
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   delete '/logout/teacher', to: 'sessions#destroy2', as: :teacher_logout                                       # 教員ログアウト処理
 
   resources :teachers do
+    get 'index2', to: 'teachers#index2', as: :teacher_index2                                              # 保護者一覧ページ
     get 'meetings/new', to: 'meetings#new'                                                                     # 面談日時登録ページ
     post 'meetings/create', to: 'meetings#create', as: :meeting_create                                         # 面談日作成
     post 'meetings/create2', to: 'meetings#create2', as: :meeting_create2                                      # 面談時間作成
@@ -50,14 +51,14 @@ Rails.application.routes.draw do
   post 'document_select/:document_item_id',to:'document_selects#create',as: :selectcreate                      #選択肢選択肢登録
   resources :document_selects
   delete 'documentitem/delete/:id',to:'documents#delete_item',as: :document_destroy                            #編集画面質問削除
-  delete 'documentSelect/delete/:id',to:'documents#delete_select',as: :document_select_destroy 
+  delete 'documentSelect/delete/:id',to:'documents#delete_select',as: :document_select_destroy
   delete "document/file_delete/:document_id",to:"documents#file_delete",as: :file_delete                       #教員ファイル削除
   get "document/public_change/:document_id",to:"documents#public_change",as: :public_change                    #保護者へ提出
   get 'select_document/first',to:'documents#select_modal',as: :select_first_modal                              #選択式最初のページモーダル
   get 'select_document/second',to:'document_items#select_modal',as: :select_second_modal                       #選択式2番目のページモーダル
   get 'select_document/third',to:'document_selects#select_modal',as: :select_third_modal                       #選択式3番目のページモーダル
   get 'input_document/first',to:'documents#input_modal',as: :input_first_modal                                 #入力式最初のページモーダル
-  get 'input_document/second',to:'document_items#input_modal',as: :input_second_modal                          #入力式2番目のページモーダル 
+  get 'input_document/second',to:'document_items#input_modal',as: :input_second_modal                          #入力式2番目のページモーダル
   get 'document_select/:id/select',to:'documents#document_modal',as: :document_select_editmodal                #選択肢編集モーダル
-  
+
 end


### PR DESCRIPTION
1. 保護者一覧の仮実装、とりあえずレイアウトはシンプルなもの
2. 保護者編集ページの仮実装、新規登録フォームとパーシャルしてすっきりさせた。
3. 保護者更新処理はシンプルな処理。
4. 生徒編集ページの仮実装、新規とは別のフォームで実装。おそらく保護者のようにパーシャル 化はできない
5. 生徒更新も同様にシンプルな処理。