### PR TITLE
Meeting

### DIFF
--- a/app/assets/stylesheets/meetings.scss
+++ b/app/assets/stylesheets/meetings.scss
@@ -27,6 +27,13 @@
   font-size: 14px;
 }
 
+.meeting-confirm-top {
+  text-align: center;
+  font-size: 40px;
+  font-weight: bold;
+  font-family: 'M PLUS Rounded 1c';
+}
+
 /* content整え */
 
 #content-meeting {
@@ -166,6 +173,13 @@
     border-style: solid;
     border-color: #dbebc4 #fff #dbebc4;
     box-shadow: -1px 1px 1px rgba(0, 0, 0, 0.15);
+}
+
+.meeting-new-user {
+    padding: 0.5em 1em;
+    margin: 2em 0;
+    background: #c1d8ac;
+    border: dashed 2px #5b8bd0;/*点線*/
 }
 
 
@@ -431,5 +445,8 @@ td.ui-datepicker-week-end a.ui-state-highlight{
   }
   .schedule-btn {
     font-size: 14px;
+  }
+  .meeting-confirm-top {
+    font-size: 19px;
   }
 }

--- a/app/assets/stylesheets/meetings.scss
+++ b/app/assets/stylesheets/meetings.scss
@@ -17,6 +17,16 @@
   font-family: 'M PLUS Rounded 1c';
 }
 
+.meeting-count {
+  text-align: center;
+  font-size: 25px;
+  font-family: 'M PLUS Rounded 1c';
+}
+
+.meeting-description {
+  font-size: 14px;
+}
+
 /* content整え */
 
 #content-meeting {
@@ -343,6 +353,11 @@ td.ui-datepicker-week-end a.ui-state-highlight{
   width: 90%;
 }
 
+.desired-user {
+  text-decoration: line-through; /* テキストの装飾に取り消し線を指定する */
+  color: blue;
+}
+
 /* スマートフォン対応 */
 
 @media screen and (max-width:767px){
@@ -351,6 +366,12 @@ td.ui-datepicker-week-end a.ui-state-highlight{
   }
   #meeting-title {
     font-size: 18px;
+  }
+  .meeting-count {
+    font-size: 18px;
+  }
+  .meeting-description {
+    font-size: 11px;
   }
   #content-meeting {
     width: 100%;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -34,7 +34,7 @@
 }
 /*表示式*/
 
-.document_user_pdf_download_p{ 
+.document_user_pdf_download_p{
   color:blue;
 }
 .document_user_answer_phone_button{display: none;}
@@ -46,6 +46,38 @@
    color: floralwhite;
    padding: 5px 10px 5px 10px;
    margin-bottom: 1%;
+}
+
+/* 先生からのお便りページ */
+.pm-content {
+  text-align: left;
+  border-bottom: dotted 2px #223a70;
+  background: #eaedf7;
+  padding-bottom: 1%;
+}
+
+.pm-reply {
+  text-align: left;
+  background: #fddea5;
+  padding-top: 1%;
+  padding-bottom: 1%;
+}
+
+/* 先生からのお便りページ背景 */
+.tm-back{
+    padding: 0.5em 1em;
+    margin: 2em 0;
+    background: #e4fcff;/*背景色*/
+    border-top: solid 6px #1dc1d6;
+    box-shadow: 0 3px 4px rgba(0, 0, 0, 0.32);/*影*/
+}
+
+.pm-back{
+    padding: 0.5em 1em;
+    margin: 2em 0;
+    background: #f1bf99;/*背景色*/
+    border-top: solid 6px #df7163;
+    box-shadow: 0 3px 4px rgba(0, 0, 0, 0.32);/*影*/
 }
 
 /* ------   スマートフォン -------   */
@@ -91,5 +123,9 @@
   }
   .document_user_answer_submit{
     margin-top: -5%;
+  }
+  /* 先生からのお便り */
+  .message-content {
+    width: 10%;
   }
 }

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -7,6 +7,8 @@ class LinebotController < ApplicationController
   def push
     if params[:commit] == "スケジュール決定送信"
       require 'line/bot'  # gem 'line-bot-api'
+      @teacher = Teacher.find(current_teacher.id)
+      @teacher.meeting_confirm_update
 
       client = Line::Bot::Client.new { |config|
         config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
@@ -99,9 +101,10 @@ class LinebotController < ApplicationController
 
     end
 
-    if params[:commit] == "日時確定送信"
+    if params[:commit] == "日時決定送信"
       require 'line/bot'
-
+      @teacher = Teacher.find(current_teacher.id)
+      @teacher.meeting_decision_update
 
       client = Line::Bot::Client.new { |config|
         config.channel_secret = ENV["LINE_CHANNEL_SECRET"]

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -235,8 +235,11 @@ class MeetingsController < ApplicationController
     @teacher = Teacher.find(params[:teacher_id])
     @meetings = @teacher.meetings.all
     @meetings_desired = @teacher.meetings.where(desired: true)
-    @meeting_times_all = @teacher.meeting_times.all
+    @meeting_times = @teacher.meeting_times.all
     @times_count = @teacher.meeting_times.map{|m| m.time.to_s(:time)}.uniq
+    @children = @teacher.children.all
+    @meeting_finish_count = 0
+    @meeting_times.each{|meeting_time| @meeting_finish_count += 1 unless meeting_time.name.blank?}
     @children_name = []
     @teacher.children.each do |child|
       @children_name << child.full_name

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -165,6 +165,10 @@ class MeetingsController < ApplicationController
     @meetings = @teacher.meetings.all
     @meeting_times = @teacher.meeting_times.all
     @times_count = @teacher.meeting_times.map{|m| m.time.to_s(:time)}.uniq
+    @meeting_times_status = @teacher.meeting_times.first.status if @meeting_times.present?
+    if @meeting_times_status == "meeting_confirm"
+      @meeting_confirm = @teacher.meeting_times.find_by(name: @child.full_name)
+    end
   end
 
   def select_date

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,4 +3,5 @@ class Meeting < ApplicationRecord
   belongs_to :child
 
   validates :date, presence: true
+
 end

--- a/app/models/meeting_time.rb
+++ b/app/models/meeting_time.rb
@@ -2,4 +2,10 @@ class MeetingTime < ApplicationRecord
   belongs_to :teacher
 
   validates :name, uniqueness: true, allow_blank: true
+  enum status:{
+    default: 0, # 初期
+    meeting_decision: 1, # 面談日時決定
+    meeting_confirm: 2, # 面談日時確定
+  }
+
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -38,4 +38,14 @@ class Teacher < ApplicationRecord
   def forget_teacher
     update_attribute(:remember_digest, nil)
   end
+
+  # 面談日時決定
+  def meeting_decision_update
+    self.meeting_times.update_all(status: :meeting_decision)
+  end
+
+  # 面談日時確定
+  def meeting_confirm_update
+    self.meeting_times.update_all(status: :meeting_confirm)
+  end
 end

--- a/app/views/meetings/edit.html.erb
+++ b/app/views/meetings/edit.html.erb
@@ -89,7 +89,7 @@
     <% end %>
     <div id="submit-center">
       <%= form_with(url: push_path, local:true) do |f| %>
-        <%= f.submit "日時確定送信", data: {confirm: "LINEグループに通知しますがよろしいですか？"}, class: "btn btn-primary submit-edit", id: "line-btn" %>
+        <%= f.submit "日時決定送信", data: {confirm: "LINEグループに通知しますがよろしいですか？"}, class: "btn btn-primary submit-edit", id: "line-btn" %>
       <% end %>
     </div>
   </div>

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -81,11 +81,13 @@
         <%= f.submit "更新", class: "btn btn-success submit-edit" %>
       </div>
     <% end %>
-    <div id="submit-center">
-      <%= form_with(url: push_path, local:true) do |f| %>
-        <%= f.submit "スケジュール決定送信", data: {confirm: "LINEグループに通知しますがよろしいですか？"}, class: "btn btn-primary submit-edit", id: "line-btn" %>
-      <% end %>
-    </div>
+    <%# if @children.count == @meeting_finish_count %> <!-- 全員決定時のみ表示 -->
+      <div id="submit-center">
+        <%= form_with(url: push_path, local:true) do |f| %>
+          <%= f.submit "スケジュール決定送信", data: {confirm: "LINEグループに通知しますがよろしいですか？"}, class: "btn btn-primary submit-edit", id: "line-btn" %>
+        <% end %>
+      </div>
+    <%# end %>
   </div>
 </div>
 

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -4,6 +4,11 @@
     面談スケジュール調整
   </div>
 
+  <div class="meeting-count">
+    <p><%= "#{@children.count}" %>人中<span style="color: blue;"><%= "#{@meeting_finish_count}" %>人</span>の日時が登録済み</p>
+    <p>あと<span style="color: red;"><%= "#{@children.count - @meeting_finish_count}" %>人</span>で保護者に日時確定メッセージを送信できます。</p>
+  </div>
+
   <div id=content class="meeting-index">
     <%= form_with(url: teacher_schedule_update_path(@teacher), method: :patch, local:true) do |f| %>
       <div class="scroll-table">
@@ -25,12 +30,17 @@
                 <td rowspan="2" class="bg-warning" id="meeting-index">
                   <% @meetings_desired.each do |meeting| %>
                     <% if meeting.date == date %>
-                      <%= Child.find(meeting.child_id).full_name %><br>
+                      <div id="<%= meeting.id %>"><%= Child.find(meeting.child_id).full_name %></div>
+                    <% end %>
+                    <% if @meeting_times.any? {|meeting_time| meeting_time.name == Child.find(meeting.child_id).full_name} %>
+                      <script>
+                        $("#<%= meeting.id %>").addClass("desired-user");
+                      </script>
                     <% end %>
                   <% end %>
                 </td>
                 <!-- 面談時間 -->
-                <% @meeting_times_all.order(:time).each do |meeting_time| %>
+                <% @meeting_times.order(:time).each do |meeting_time| %>
                     <% if meeting_time.time.to_date == date %>
                       <td class="bg-info" style="min-width: 100px"><%= meeting_time.time.to_s(:time) %></td>
                     <% end %>
@@ -38,7 +48,7 @@
               </tr>
               <tr>
                 <!-- 面談者名 -->
-                <% @meeting_times_all.each do |meeting_time| %>
+                <% @meeting_times.each do |meeting_time| %>
                   <% if meeting_time.time.to_date == date %>
                     <%= fields_for "meeting_times[]", meeting_time do |af| %>
                       <% unless meeting_time.name.present? %>
@@ -62,6 +72,10 @@
             <% end %>
           </tbody>
         </table>
+      </div>
+      <div class="meeting-description">
+        <p><i class="fas fa-exclamation-triangle"></i>選択肢には保護者が面談可能な日時の部分にまだ日時が決まっていない保護者の名前が表示されます。</p>
+        <p><i class="fas fa-exclamation-triangle"></i>保護者の名前をクリックすることでその部分をキャンセルでき、選択肢にもキャンセルした保護者の名前が表示されるようになります。</p>
       </div>
       <div id="submit-center">
         <%= f.submit "更新", class: "btn btn-success submit-edit" %>

--- a/app/views/meetings/index2.html.erb
+++ b/app/views/meetings/index2.html.erb
@@ -6,8 +6,8 @@
 
   <div id="content-meeting" class="meeting-status">
     <div id="meeting-title" class="bg-info" style="border-radius:12px;">
-      <div><span style="color: blue;"><%= "#{@children.count}" %>人中</span><span style="color: red;"><%= "#{@desired_count}" %>人返信済み</span></div>
-      <div style="color: red;">あと<%= @children.count - @desired_count %>人でスケジュール調整可能です。</div>
+      <div><%= "#{@children.count}" %>人中<span style="color: blue;"><%= "#{@desired_count}" %>人</span>返信済み</div>
+      <div>あと<span style="color: red;"><%= @children.count - @desired_count %>人</span>でスケジュール調整可能です。</div>
     </div>
 
     <table class="table-bordered table-striped table-condensed meeting-table bg-success" style="width: 100%; margin-top: 20px;">

--- a/app/views/meetings/new_user.html.erb
+++ b/app/views/meetings/new_user.html.erb
@@ -1,17 +1,21 @@
 <div class="meeting-back">
-  <div id="meeting-top-title"><%= @child.full_name %>さんの面談管理ページ</div>
+  <div id="meeting-top-title"><%= @child.full_name %>さんの<br>面談管理ページ</div>
 
-  <% unless @meeting_children.present? %>
-    <h1 id="meeting-top-title">現在面談予定はございません。</h1>
-  <% else %>
-
-    <!-- 子供が二人以上いた場合 -->
-    <% unless @children.count == 1 %>
-      <h2 id="meeting-title">管理ページの切り替えはこちらから</h2>
-      <% @children.each do |child| %>
-        <p style="text-align: center;" id="meeting-title"><%= link_to "#{child.full_name}さんの管理ページへ", user_meetings_new_user_path(@user, child) unless child.id == @child.id %></p>
-      <% end %>
+  <!-- 子供が二人以上いた場合 -->
+  <% unless @children.count == 1 %>
+    <h2 id="meeting-title">管理ページの切り替えはこちらから</h2>
+    <% @children.each do |child| %>
+      <p style="text-align: center;" id="meeting-title"><%= link_to "#{child.full_name}さんの管理ページへ", user_meetings_new_user_path(@user, child) unless child.id == @child.id %></p>
     <% end %>
+  <% end %>
+
+  <% if @meeting_times_status == "meeting_confirm" %>
+    <h1 id="meeting-top-title" class="bg-info">面談日時が確定しました。</h1>
+    <div class="meeting-confirm-top meeting-new-user">
+      <div><%= @child.full_name %>さんの面談日時は</div>
+      <div><span style="color: red;">「<%= @meeting_confirm.time.to_s(:full_time) if @meeting_times.present? %>」</span></div>
+    </div>
+  <% elsif @meeting_times_status == "meeting_decision" %>
 
     <div class="meeting-user">
       <table class="table-bordered table-striped table-condensed meeting-table" style="width: 100%; margin-top: 20px; background-color: #ffffff;">
@@ -140,8 +144,11 @@
         <% end %>  <!-- if meeting.desired == true -->
       <% end %>  <!-- @meeting_children.each do |meeting| -->
     </div>
-  <% end %>  <!-- unless @meeting_children.present? -->
+  <% else %>
+    <h1 id="meeting-top-title">現在面談予定はございません。</h1>
+  <% end %>  <!-- @meeting_times_status -->
 </div>
+
 
 <style>
   body {

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -1,59 +1,80 @@
-<h1 id="meeting-top-title">先生からのお便り一覧</h1>
+<div class="tm-back">
+  <h1 id="meeting-top-title">先生からのお便り一覧</h1>
 
-<% if @t_messages.first.present? %>
+  <% if @t_messages.first.present? %>
+    <table class="table-bordered table-striped table-condensed meeting-table" style="width: 100%; margin-top: 20px;">
+      <thead>
+        <tr style="background: #FF9933; color: white;">
+          <td>日付</td>
+          <td>タイトル</td>
+          <td>内容</td>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @t_messages.each do |t_message| %>
+          <% unless t_message_content(t_message, @user).blank? %>
+            <tr>
+              <!-- 日付 -->
+              <td style="width: 30%;"><%= t_message.created_at.to_s(:date) %></td>
+              <!-- タイトル -->
+              <td><%= t_message.title %></td>
+              <!-- 内容 -->
+              <td class="message-content" data-toggle="collapse" data-target="#tm-<%= t_message.id %>" aria-expanded="false" aria-controls="collapseExample2">
+                <%= button_tag "内容", class: "btn btn-success" %>
+              </td>
+            </tr>
+            <tr class="collapse" id="tm-<%= t_message.id %>">
+              <td colspan="3" class="bg-warning" style="text-align: left;"><span style="color: green;">内容</span>：<br><%= t_message.content %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div id="meeting-title">お便りなし</div>
+  <% end %>
+</div>
+
+<div class="pm-back">
+  <h1 id="meeting-top-title">先生からの返信</h1>
+
+  <% if @p_messages.any? {|p_message| p_message.reply.present?} %>
+
   <table class="table-bordered table-striped table-condensed meeting-table" style="width: 100%; margin-top: 20px;">
     <thead>
       <tr style="background: #FF9933; color: white;">
-        <td>日付</td>
+        <td>返信日</td>
         <td>タイトル</td>
         <td>内容</td>
       </tr>
     </thead>
 
     <tbody>
-      <% @t_messages.each do |t_message| %>
-        <% unless t_message_content(t_message, @user).blank? %>
+      <% @p_messages.each do |p_message| %>
           <tr>
-            <!-- 日付 -->
-            <td><%= t_message.created_at.to_s(:date) %></td>
-            <!-- タイトル -->
-            <td><%= t_message.title %></td>
-            <!-- 内容 -->
-            <td><%= t_message_content(t_message, @user) %></td>
+            <td><%= p_message.updated_at.to_s(:date) %></td>
+            <td><%= p_message.title %></td>
+            <td class="message-content" data-toggle="collapse" data-target="#pm-<%= p_message.id %>" aria-expanded="false" aria-controls="collapseExample2">
+              <%= button_tag "内容", class: "btn btn-success" %>
+            </td>
           </tr>
-        <% end %>
+          <tr class="collapse" id="pm-<%= p_message.id %>">
+            <td colspan="3">
+            <div class="pm-content"><span style="color: blue;">相談内容</span>：<br><%= p_message.content %></div>
+            <div class="pm-reply"><span style="color: red;">返信内容</span>：<br><%= p_message.reply if p_message.reply.present? %></div>
+            </td>
+          </tr>
       <% end %>
     </tbody>
   </table>
-<% else %>
-  <div id="meeting-title">お便りなし</div>
-<% end %>
+  <% else %>
+    <div id="meeting-title">返信なし</div>
+  <% end %>
+</div>
 
-<h1 id="meeting-top-title">先生からの返信</h1>
-
-<% if @p_messages.any? {|p_message| p_message.reply.present?} %>
-
-<table class="table-bordered table-striped table-condensed meeting-table" style="width: 100%; margin-top: 20px;">
-  <thead>
-    <tr style="background: #FF9933; color: white;">
-      <td>返信日</td>
-      <td>タイトル</td>
-      <td>相談内容</td>
-      <td>返信内容</td>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @p_messages.each do |p_message| %>
-        <tr>
-          <td><%= p_message.updated_at.to_s(:date) %></td>
-          <td><%= p_message.title %></td>
-          <td><%= p_message.content %></td>
-          <td><%= p_message.reply if p_message.reply.present? %></td>
-        </tr>
-    <% end %>
-  </tbody>
-</table>
-<% else %>
-  <div id="meeting-title">返信なし</div>
-<% end %>
+<style>
+  body {
+    background-color: #f7f5e6;;
+  }
+</style>

--- a/app/views/users/messages.html.erb
+++ b/app/views/users/messages.html.erb
@@ -31,6 +31,7 @@
 
 <h1 id="meeting-top-title">先生からの返信</h1>
 
+<% if @p_messages.any? {|p_message| p_message.reply.present?} %>
 
 <table class="table-bordered table-striped table-condensed meeting-table" style="width: 100%; margin-top: 20px;">
   <thead>
@@ -53,3 +54,6 @@
     <% end %>
   </tbody>
 </table>
+<% else %>
+  <div id="meeting-title">返信なし</div>
+<% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,2 +1,3 @@
 Time::DATE_FORMATS[:date] = '%Y-%m-%d'
 Time::DATE_FORMATS[:time] = '%H:%M'
+Time::DATE_FORMATS[:full_time] = '%Y年%m月%d日 %H時%M分'

--- a/db/migrate/20191118063648_create_meeting_times.rb
+++ b/db/migrate/20191118063648_create_meeting_times.rb
@@ -3,6 +3,7 @@ class CreateMeetingTimes < ActiveRecord::Migration[5.1]
     create_table :meeting_times do |t|
       t.datetime :time
       t.string :name
+      t.integer :status, default: 0
       t.references :teacher, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20191203130047) do
   create_table "meeting_times", force: :cascade do |t|
     t.datetime "time"
     t.string "name"
+    t.integer "status", default: 0
     t.integer "teacher_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
1. 面談調整ページに説明文追加と選択済みユーザーを希望者列で取り消し線でわかりやすく
2. 日時決定ボタンを押さないと保護者の面談ページで希望日等の入力ができないようにメッセージを表示。
3. 同様にスケジュール決定ボタンを押した後は希望日等の入力をできなくして決まった日時を表示する。
4. 先生からのお便りページで先生からの返信がない場合は返信なしと表示
5. 先生からのお便りページのレイアウトを変更、内容はアコーディオンで表示。およびレスポンシブ対応。